### PR TITLE
Add copy function and update import and export functions

### DIFF
--- a/bv_event_string.m
+++ b/bv_event_string.m
@@ -1,0 +1,52 @@
+% bv_event_string() - converts an EEG.events entry to the string for Brain
+% Vision .vmrk files. Uses the CODE field for the MK#= entry, and the type
+% field for the marker description. 
+%
+% Usage:
+%   >> out_text = bv_event_string(event, marker_number)
+%
+% Inputs:
+%   event         - EEG.event structure (e.g., EEG.event(1) as input)
+%
+% This function uses the events. 
+%
+% Author: Joshua D. Koen
+
+% Copyright (C) 2019, Joshua Koen jkoen@nd.edu
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; if not, write to the Free Software
+% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+function out_text = bv_event_string(event, marker_number)
+
+if ~isstruct(event)
+    error('input must be a strcutre variable.')
+elseif ~all(isfield(event,{'code','type','latency', 'duration'}))
+    error('input must have latency, duration, code and type fields.')
+end
+
+% If event.type is boundary, replace with ''
+if strcmp(event.type,'boundary')
+    event.type = '';
+end
+
+% Define out_text string
+out_text = sprintf('Mk%d=%s,%s,%d,%d,0', ...
+    marker_number, ...
+    char(event.code), ...
+    char(event.type), ...
+    event.latency, ...
+    event.duration );
+
+end % of function

--- a/bv_text_catcher.m
+++ b/bv_text_catcher.m
@@ -1,0 +1,45 @@
+% bv_text_catcher() - checks information in a line of text from a .vhdr or
+% .vmrk file for the DataFile= or MarkerFile= lines to update them
+% appropriately.
+%
+% Usage:
+%   >> out_text = pop_writebva(in_text,DataFile,MarkerFile);   % a window pops up
+%   >> EEG = pop_writebva(EEG, filename);
+%
+% Inputs:
+%   EEG            - eeglab dataset
+%   filename       - file name
+%
+% Author: Joshua D. Koen
+
+% Copyright (C) 2019, Joshua Koen jkoen@nd.edu
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; if not, write to the Free Software
+% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+function out_text = bv_text_catcher(in_text, DataFile, MarkerFile);
+
+% Error Check
+if ~ischar(in_text) || ~ischar(DataFile) || ~ischar(MarkerFile) || nargin < 3
+    error('bv_file_catcher requires string inputs for in_text, DataFile, and MarkerFile');
+end
+
+
+if all(ismember('DataFile=',in_text)) % DataFile replace
+    out_text = sprintf('DataFile=%s', DataFile);
+elseif all(ismember('MarkerFile=', in_text)) % MarkerFile replace
+    out_text = sprintf('MarkerFile=%s', MarkerFile);
+else % Otherwise simply pass it in
+    out_text = in_text;
+end

--- a/eegplugin_bva_io.m
+++ b/eegplugin_bva_io.m
@@ -69,9 +69,13 @@ function vers = eegplugin_bva_io(fig, trystrs, catchstrs)
         comcnt2 = [ trystrs.no_check '[EEG LASTCOM] = pop_loadbva;' catchstrs.new_non_empty ];
     end;
     comcnt3 = [ trystrs.no_check 'LASTCOM = pop_writebva(EEG);'  catchstrs.add_to_hist ];
+    comcnt4 = [ trystrs.no_check 'LASTCOM = pop_writebva2(EEG);'  catchstrs.add_to_hist ];
+    comcnt5 = [ trystrs.no_check 'LASTCOM = pop_copybv();' catchstrs.add_to_hist ];
                 
     % create menus
     % ------------
     uimenu( menui, 'label', 'From Brain Vis. Rec. .vhdr file',  'callback', comcnt1, 'separator', 'on' );
     uimenu( menui, 'label', 'From Brain Vis. Anal. Matlab file', 'callback', comcnt2 );
     uimenu( menuo, 'label', 'Write Brain Vis. exchange format file',  'callback', comcnt3, 'separator', 'on' );
+    uimenu( menuo, 'label', 'Write Brain Vis. exchange format **NEW**',  'callback', comcnt4, 'separator', 'on' );
+    uimenu( menuo, 'label', 'Copy and Rename Brain Vis. exchange files', 'callback', comcnt5 );

--- a/pop_copybv.m
+++ b/pop_copybv.m
@@ -1,0 +1,151 @@
+% pop_copybv - copy a BVA file set and updates with new DataFile and
+% MarkerFile lines in .vhdr and .vmrk files. Also updates events with
+% EEG.events structure (if provided. 
+% 
+% Usage:
+%   >> [com] = pop_copybv();   % a window pops up for input file and output files
+%   >> [com] = pop_copybv(vhdr_file);   % a window pops up for outputfile
+
+%   >> [com] = pop_copybv(vhdr_file, outputfile, EEG); 
+%
+% Inputs:
+%   vhdr_file      - vdhr_file to copy
+%   outputfile     - new file name (including path if different than pwd)
+%   EEG            - EEG structure to extract events from (if empty, simple
+%                    copy of original vmrk file.
+%
+% If copying events from EEG.events, uses code for marker type
+% (Mk1=EEG.event(i).code) and type as description
+%   
+%
+% Author: Joshua Koen, UND
+
+% Copyright (C) 2019, Joshua Koen jkoen@nd.edu
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; if not, write to the Free Software
+% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+function com = pop_copybv( vhdr_file, outputfile, EEG );
+
+% initialize com
+com = '';
+
+% handle vhdr_file
+if nargin < 1
+    [vhdr_file hdrpath] = uigetfile2('*.vhdr', 'Select Brain Vision vhdr-file - pop_copybv()');
+    if length( vhdr_file ) == 0 return; end;
+    vhdr_file = fullfile(hdrpath,vhdr_file); % Remove extension
+end
+
+% Handle output file (Removes dot extension)
+if nargin < 2
+    [outputfile, outputpath] = uiputfile('*', 'Output file');
+    if length( outputfile ) == 0 return; end;    
+    outputfile = fullfile(outputpath,outputfile);
+end
+
+% Remove extensions
+[hdrpath vhdr_file] = fileparts(vhdr_file); 
+[outputpath outputfile] = fileparts(outputfile);
+
+% Open input vhdr and vmrk files for reading
+vhdr_in = fopen( fullfile(hdrpath, [vhdr_file '.vhdr']), 'r' );
+vmrk_in = fopen( fullfile(hdrpath, [vhdr_file '.vmrk']), 'r' );
+
+% Open output paths for writing
+vhdr_out = fopen( fullfile(outputpath, [outputfile '.vhdr']), 'w' );
+vmrk_out = fopen( fullfile(outputpath, [outputfile '.vmrk']), 'w' );
+
+% File output names for .vhdr
+DataFile = [ outputfile '.eeg' ];
+MarkerFile = [ outputfile '.vmrk' ];
+
+% Update header DataFile and MarkerFile
+disp('pop_copybv(): copying and updating header file');
+while ~feof(vhdr_in)
+    this_line = fgetl(vhdr_in);
+    this_line = bv_text_catcher(this_line, DataFile, MarkerFile);
+    fwrite(vhdr_out,sprintf('%s\n',this_line));
+end
+
+% Deal with the vmrk output
+if ~exist('EEG','var')
+    
+    disp('pop_copybv(): copying marker file');
+    while ~feof(vmrk_in)
+        this_line = fgetl(vmrk_in);
+        this_line = bv_text_catcher(this_line, DataFile, MarkerFile);
+        fwrite(vmrk_out,sprintf('%s\r',this_line));
+    end
+    
+else % Update with EEG event info
+    
+    disp('pop_copybv(): copying and updating marker file');
+    e = EEG.event;
+    copy_events = false;
+    
+    % Copy stuff until events
+    index = 1;
+    while ~feof(vmrk_in)
+        % read line
+        this_line = fgetl(vmrk_in);
+        
+        
+        
+        % Check if I should stop
+        if ~copy_events
+            % Update data file
+            this_line = bv_text_catcher(this_line, DataFile, MarkerFile);
+            
+            % Try and find the first marker line (Mk1)
+            try
+                if all(ismember('Mk',this_line(1:2))) % Once markers are reached, add stuff
+                    copy_events = true;
+                end
+            catch
+            end
+        
+        end
+        
+        % Separate from above so it will do the things in the same
+        % iteration
+        if copy_events
+            
+            % Handle event marker conversion. This will only do so if there is
+            % not a new segment (preserves 
+            if ~all(ismember('New Segment',this_line)) % If a new segment is present
+                if ~strcmpi(e(index).code,'New Segment')
+                    this_line = bv_event_string(e(index), index);
+                end
+            end
+            index = index + 1; % Increment index
+            
+        end
+        
+        % Write stuff
+        fwrite(vmrk_out,sprintf('%s\r',this_line));
+        
+    end
+    
+end
+
+% Simply copy the .egg file
+disp('pop_copybv(): copying data (.eeg) file');
+copyfile(fullfile(hdrpath, [vhdr_file '.eeg']), fullfile(outputpath, [outputfile '.eeg']));
+        
+% Close files
+fclose('all');
+        
+%
+end % of function

--- a/pop_loadbv.m
+++ b/pop_loadbv.m
@@ -449,11 +449,29 @@ end
 
 EEG.ref = 'common';
 
+% Add BV .vhdr to EEG.etc.bv_vhdr
+fid = fopen(fullfile(path,hdrfile),'r');
+hdr_info = '';
+while ~feof(fid)
+    hdr_info = vertcat(hdr_info, {fgetl(fid)});
+end
+fclose(fid);
+EEG.etc.bv_vhdr_file = hdr_info;
+
+% Add BV .vmrk to EEG.etc.bv_vmrk_file
+fid = fopen(fullfile(path,strrep(hdrfile,'.vhdr','.vmrk')),'r');
+vmrk_info = '';
+while ~feof(fid)
+    vmrk_info = vertcat(vmrk_info, {fgetl(fid)});
+end
+fclose(fid);
+EEG.etc.bv_vmrk_file = vmrk_info;
+
 try
     EEG = eeg_checkset(EEG);
 catch
 end
 
 if nargout == 2
-    com = fprintf('EEG = pop_loadbv(''%s'', ''%s'', %s, %s);', path, hdrfile, mat2str(srange), mat2str(chans) );
+    com = sprintf('EEG = pop_loadbv(''%s'', ''%s'', %s, %s);', path, hdrfile, mat2str(srange), mat2str(chans) );
 end

--- a/pop_writebva2.m
+++ b/pop_writebva2.m
@@ -1,0 +1,140 @@
+% pop_writebva() - export EEG dataset
+% 
+% Usage:
+%   >> EEG = pop_writebva(EEG);   % a window pops up
+%   >> EEG = pop_writebva(EEG, filename);
+%
+% Inputs:
+%   EEG            - eeglab dataset
+%   filename       - file name
+%
+% Author: Arnaud Delorme, SCCN, INC, UCSD, 2005-
+
+% Copyright (C) 2005, Arnaud Delorme, SCCN, INC, UCSD, arno@salk.edu
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program; if not, write to the Free Software
+% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+function com = pop_writebva(EEG, filename); 
+
+com = '';
+if nargin < 1 
+    help pop_writebva;
+    return;
+end;
+
+if nargin < 2
+    [filename, filepath] = uiputfile('*', 'Output file');
+    if length( filepath ) == 0 return; end;
+    filename = [ filepath filename ];
+end;
+
+% remove extension if any
+% -----------------------
+posdot = find(filename == '.');
+if ~isempty(posdot), filename = filename(1:posdot(end)-1); end;
+
+% open output file
+% ----------------
+fid1 = fopen( [ filename '.vhdr' ], 'w' );
+fid2 = fopen( [ filename '.vmrk' ], 'w' );
+fid3 = fopen( [ filename '.dat'  ], 'wb', 'ieee-le');
+[ tmppath basename ] = fileparts( filename );
+
+% write data
+% ----------
+for index = 1:EEG.nbchan
+    fwrite(fid3, EEG.data(index,:), 'float' );
+end;
+
+% write header
+% ------------
+fprintf(fid1, 'Brain Vision Data Exchange Header File Version 1.0\n');
+fprintf(fid1, '; Data created from the EEGLAB software\n');
+fprintf(fid1, '\n');
+fprintf(fid1, '[Common Infos]\n');
+fprintf(fid1, 'DataFile=%s\n', [ basename '.dat'  ]);
+if ~isempty(EEG.event)
+    fprintf(fid1, 'MarkerFile=%s\n', [ basename '.vmrk' ]);
+end;
+fprintf(fid1, 'DataFormat=BINARY\n');
+fprintf(fid1, '; Data orientation: VECTORIZED=ch1,pt1, ch1,pt2..., MULTIPLEXED=ch1,pt1, ch2,pt1 ...\n');
+fprintf(fid1, 'DataOrientation=VECTORIZED\n');
+fprintf(fid1, 'DataType=TIMEDOMAIN\n');
+fprintf(fid1, 'NumberOfChannels=%d\n', EEG.nbchan);
+fprintf(fid1, 'DataPoints=%d\n', EEG.pnts*EEG.trials);
+fprintf(fid1, '; Sampling interval in microseconds if time domain (convert to Hertz:\n');
+fprintf(fid1, '; 1000000 / SamplingInterval) or in Hertz if frequency domain:\n');
+fprintf(fid1, 'SamplingInterval=%d\n', 1000000/EEG.srate);
+if EEG.trials > 1
+    fprintf(fid1, 'SegmentationType=MARKERBASED\n');
+end;
+fprintf(fid1, '\n');
+fprintf(fid1, '[Binary Infos]\n');
+fprintf(fid1, 'BinaryFormat=IEEE_FLOAT_32\n');
+fprintf(fid1, '\n');
+if ~isempty(EEG.chanlocs)
+    fprintf(fid1, '[Channel Infos]\n');
+    fprintf(fid1, '; Each entry: Ch<Channel number>=<Name>,<Reference channel name>,\n');
+    fprintf(fid1, '; <Resolution in microvolts>,<Future extensions..\n');
+    fprintf(fid1, '; Fields are delimited by commas, some fields might be omited (empty).\n');
+    fprintf(fid1, '; Commas in channel names are coded as "\1".\n');
+    for index = 1:EEG.nbchan
+        fprintf(fid1, 'Ch%d=%s,, \n', index, EEG.chanlocs(index).labels);
+    end;
+    fprintf(fid1, '\n');
+
+    disp('Warning: channel location were not exported to BVA (it will use default');
+    disp('         10-20 BESA locations based on channel names)');
+    %if isfield(EEG.chanlocs, 'sph_radius')
+    %    fprintf(fid1, '[Coordinates]\n');
+    %    fprintf(fid1, '; Each entry: Ch<Channel number>=<Radius>,<Theta>,<Phi>\n');
+    %    loc = convertlocs(EEG.chanlocs, 'sph2sphbesa');
+    %    for index = 1:EEG.nbchan
+    %        fprintf(fid1, 'Ch%d=%d,%d,%d\n', index, round(loc(index).sph_theta_besa), ...
+    %                                        round(loc(index).sph_phi_besa), 0);
+    %    end;
+    %end;
+end;
+
+% export event information
+% ------------------------
+if ~isempty(EEG.event)
+    fprintf(fid2, 'Brain Vision Data Exchange Marker File, Version 1.0\n');
+    fprintf(fid2, '; Data created from the EEGLAB software\n');
+    fprintf(fid2, '; The channel numbers are related to the channels in the exported file.\n');
+    fprintf(fid2, '\n');
+    fprintf(fid2, '[Common Infos]\n');
+    fprintf(fid2, 'DataFile=%s\n', [ basename '.dat'  ]);
+    fprintf(fid2, '\n');
+    fprintf(fid2, '[Marker Infos]\n');
+    fprintf(fid2, '; Each entry: Mk<Marker number>=<Type>,<Description>,<Position in data points>,\n');
+    fprintf(fid2, '; <Size in data points>, <Channel number (0 = marker is related to all channels)>,\n');
+    fprintf(fid2, '; <Date (YYYYMMDDhhmmssuuuuuu)>\n');
+    fprintf(fid2, '; Fields are delimited by commas, some fields might be omited (empty).\n');
+    fprintf(fid2, '; Commas in type or description text are coded as "\1".\n');
+    
+    % Write event directly from EVENTs structure
+    for index = 1:length(EEG.event)
+        this_event = bv_event_string(EEG.event(index), index);
+        fprintf(fid2, '%s\n', this_event);
+    end
+end;
+
+fclose(fid1);
+fclose(fid2);
+fclose(fid3);
+
+com = sprintf('pop_writebva(%s,''%s'');', inputname(1), filename); 
+return;


### PR DESCRIPTION
I updated some code to handle parsing the channel information (specifically units) and reading in all of the .vhdr and .vmrk files into a cell array in EEG.etc.bv_vhdr_file and EEG.etc.bv_vmrk_file, respectively. These can be used to modify write functions (in the future) to copy directly information from these files. This will help keep up with formatting these files should anything change with Brain Vision. 

I have also added some utility functions (bv_event_string and bv_text_catcher) to get at things that appeared multiple times in the load/write functions. 

I also added functions to copy (and rename) a brain vision dataset (.vhdr, .eeg, and .vmrk) files. This is pop_copybv(). If using scripting, this can also specify a loaded EEG dataset to copy the event markers from (except for boundaries and new segments). 

I also added a 'new' pop_writebva function (pop_writebva2) that simply uses the code and type files to write markers without the relabeling present in pop_writebva.