### PR TITLE
Ahdr format

### DIFF
--- a/eegplugin_bva_io.m
+++ b/eegplugin_bva_io.m
@@ -1,5 +1,5 @@
 % eegplugin_bva_io() - EEGLAB plugin for importing Brainvision 
-%                         .vhdr data files.
+%                         .vhdr and .ahdr data files.
 %
 % Usage:
 %   >> eegplugin_bva_io(fig, trystrs, catchstrs);
@@ -73,7 +73,7 @@ function vers = eegplugin_bva_io(fig, trystrs, catchstrs)
                 
     % create menus
     % ------------
-    uimenu( menui, 'label', 'From Brain Vis. Rec. .vhdr file',  'callback', comcnt1, 'separator', 'on' );
+    uimenu( menui, 'label', 'From Brain Vis. Rec. .vhdr or .ahdr file',  'callback', comcnt1, 'separator', 'on' );
     uimenu( menui, 'label', 'From Brain Vis. Anal. Matlab file', 'callback', comcnt2 );
     uimenu( menuo, 'label', 'Write Brain Vis. exchange format file',  'callback', comcnt3, 'separator', 'on' );
     uimenu( menuo, 'label', 'Copy and Rename Brain Vis. exchange files', 'callback', comcnt4 );

--- a/pop_copybv.m
+++ b/pop_copybv.m
@@ -80,7 +80,7 @@ while ~feof(vmrk_in)
     fwrite(vmrk_out,sprintf('%s\n',this_line));
 end
 
-% Simply copy the .egg file
+% Simply copy the .eeg file
 disp('pop_copybv(): copying data (.eeg) file');
 copyfile(fullfile(hdrpath, [vhdr_file '.eeg']), fullfile(outputpath, [outputfile '.eeg']));
         

--- a/pop_loadbv.m
+++ b/pop_loadbv.m
@@ -59,7 +59,7 @@ com = '';
 EEG = [];
 
 if nargin < 2
-    [hdrfile path] = uigetfile2('*.vhdr', 'Select Brain Vision vhdr-file - pop_loadbv()');
+    [hdrfile path] = uigetfile2({'*.vhdr';'*.ahdr'}, 'Select Brain Vision a/vhdr-file - pop_loadbv()');
     if hdrfile(1) == 0, return; end
 
     drawnow;

--- a/pop_loadbv.m
+++ b/pop_loadbv.m
@@ -10,7 +10,7 @@
 %
 % Optional inputs:
 %   path      - path to files
-%   hdrfile   - name of Brain Vision vhdr-file (incl. extension)
+%   hdrfile   - name of Brain Vision vhdr- or ahdr-file (incl. extension)
 %   srange    - scalar first sample to read (up to end of file) or
 %               vector first and last sample to read (e.g., [7 42];
 %               default: all)
@@ -24,7 +24,7 @@
 % Note:
 %   Import "Brain Vision Data Exchange" format files with this function.
 %   Brain Vision Data Exchange files consist of a set of 3 files, a header
-%   file (.vhdr), a marker file (.vmrk), and a data file. Export from
+%   file (.vhdr or .ahdr), a marker file (.vmrk), and a data file. Export from
 %   BrainVision Analyzer with "Generic Data" export. Select header and
 %   marker file for export (text format; XML format is not yet supported).
 %   Binary and text data formats, in both multiplexed and vectorized data
@@ -59,7 +59,7 @@ com = '';
 EEG = [];
 
 if nargin < 2
-    [hdrfile path] = uigetfile2({'*.vhdr';'*.ahdr'}, 'Select Brain Vision a/vhdr-file - pop_loadbv()');
+    [hdrfile path] = uigetfile2({'*.vhdr;*.ahdr'}, 'Select Brain Vision a/vhdr-file - pop_loadbv()');
     if hdrfile(1) == 0, return; end
 
     drawnow;

--- a/readbvconf.m
+++ b/readbvconf.m
@@ -87,7 +87,7 @@ for iSection = 1:length(sectionArray) - 1
                 CONF.(fieldName)(str2double(raw{line}(3:splitArray(1) - 1))) = {raw{line}(splitArray(1) + 1:end)};
             end
             if strcmp(ext,'.ahdr')
-                CONF.(fieldName)(ahdrChannels) = 'test,,1,mV';
+                CONF.(fieldName)(ahdrChannels) = {'test,,1,mV'};
             end
         case {'coordinates'} % if ahdr add info on the fake channel
             for line = sectionArray(iSection) + 1:sectionArray(iSection + 1) - 1
@@ -95,7 +95,7 @@ for iSection = 1:length(sectionArray) - 1
                 CONF.(fieldName)(str2double(raw{line}(3:splitArray(1) - 1))) = {raw{line}(splitArray(1) + 1:end)};
             end
             if strcmp(ext,'.ahdr')
-                %TODO CHECK COORDINATES INFO
+                CONF.(fieldName)(ahdrChannels) = {'0,0,0'};
             end
         case {'markerinfos'} % Allow discontinuity for markers (but not channelinfos and coordinates!)
             for line = sectionArray(iSection) + 1:sectionArray(iSection + 1) - 1


### PR DESCRIPTION
The vAmp amplifier saves the data in the ahdr format and therefore these files are not readable by EEGLAB. The ahdr format is a very basic encryption method: basically it adds one fake channel to the eeg data, while in the header the number of channel is set as the original number. In this fork I change the reading of the hdr file by adding one fake channel (only if the format is ahdr, for vhdr the behavior is exactly the same as before), therefore now it is possible to load the ahdr files directly in EEGLAB. The new fake channel will be loaded as well in the dataset, but it is named as "test", this should avoid any confusion.