### PR TITLE
Update pop_loadbv.m

### DIFF
--- a/pop_loadbv.m
+++ b/pop_loadbv.m
@@ -93,7 +93,7 @@ catch
 end
 EEG.comments = ['Original file: ' hdr.commoninfos.datafile];
 hdr.commoninfos.numberofchannels = str2double(hdr.commoninfos.numberofchannels);
-EEG.srate = 1000000 / str2double(hdr.commoninfos.samplinginterval);
+EEG.srate = round(1000000 / str2double(hdr.commoninfos.samplinginterval));
 
 % Binary Infos
 if strcmpi(hdr.commoninfos.dataformat, 'binary')


### PR DESCRIPTION
Problem: Importing files using pop_loadbv causes the incorrect sample rate.
I'm not sure if this is the best solution, but if EEG.srate is not a round number, it will crash many functions, downsample for example.
Solution: Round EEG.srate to compensate for a lack of precision in str2double. 
Example: If my sampling interval is 833.3333 reoccurring and the string input from the hdr.commoninfos.samplinginterval is 12 decimal places or less str2double converts it to 833.3333 which calculates to 1.200000000000001e+03 which causes downsampling and other functions to crash later on.

Could add a check and warning if round is required?